### PR TITLE
Normalize path handling in BIOS update script

### DIFF
--- a/UpdateBIOS.ps1
+++ b/UpdateBIOS.ps1
@@ -21,7 +21,8 @@ if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]:
 
 # Define log file
 $hostname = $env:COMPUTERNAME
-$logFile = ".\\LOGS\BIOSUpdate_$hostname.log"
+# Use normal path separators; no escaping required
+$logFile = ".\LOGS\BIOSUpdate_$hostname.log"
 Function Write-Log {
     param (
         [string]$Message
@@ -67,7 +68,7 @@ function Update-BIOS {
         Write-Log "Updating BIOS for $SystemFamily from version $currentVersion to $ExpectedVersion"
 
         # Define local directory
-        $localDir = "C:\\Temp\\BIOSUpdate"
+        $localDir = "C:\Temp\BIOSUpdate"
         if (!(Test-Path -Path $localDir)) {
             New-Item -Path $localDir -ItemType Directory | Out-Null
         }
@@ -80,11 +81,11 @@ function Update-BIOS {
 
         # Clear local directory before copying
         Write-Log "Clearing local directory: $localDir"
-        Remove-Item -Path "$localDir\\*" -Recurse -Force -ErrorAction SilentlyContinue
+        Remove-Item -Path (Join-Path $localDir '*') -Recurse -Force -ErrorAction SilentlyContinue
 
         # Copy BIOS update files (including subfolders)
         Write-Log "Copying BIOS update files from $RemotePath to $localDir..."
-        Copy-Item -Path "$RemotePath\\*" -Destination $localDir -Recurse -Force
+        Copy-Item -Path (Join-Path $RemotePath '*') -Destination $localDir -Recurse -Force
 
         # Identify the correct BIOS update executable
         $exeFile = Get-ChildItem -Path $localDir -Filter "WINUPTP64.EXE" -Recurse | Select-Object -First 1
@@ -126,7 +127,7 @@ function Update-BIOS {
 
         # Run BIOS update from local directory
         Write-Log "Executing BIOS update: $($exeFile.FullName) with arguments: $installArgs"
-        Start-Process -FilePath "$($exeFile.FullName)" -ArgumentList "$installArgs" -WorkingDirectory "C:\Temp\BIOSUpdate" -Passthru -Wait
+        Start-Process -FilePath $exeFile.FullName -ArgumentList $installArgs -WorkingDirectory $localDir -Passthru -Wait
 
         # Prompt for restart
         #$restart = Read-Host "BIOS update complete for $SystemFamily. Restart is required. Restart now? (Y/N)"
@@ -137,7 +138,7 @@ function Update-BIOS {
 
         # Clean up files (optional)
         Write-Log "Cleaning up local BIOS update files"
-        Remove-Item -Path "$localDir\\*" -Recurse -Force
+        Remove-Item -Path (Join-Path $localDir '*') -Recurse -Force
     } else {
         Write-Log "BIOS for $SystemFamily is already up-to-date (Version: $currentVersion)"
     }
@@ -145,17 +146,17 @@ function Update-BIOS {
 
 # BIOS Configuration Dictionary for Lenovo SystemFamily
 $biosUpdates = @(
-    @{ Family = "ThinkPad T490s"; Version = "N2JETA7W (1.85 )"; Path = ".\\ThinkPad T490s" }, # Updated 12/12/2024, BIOS version confirmed
-    @{ Family = "ThinkPad T14s Gen 1"; Version = "N2YET25W (1.14 )"; Path = ".\\ThinkPad T14s Gen 1" }, # Updated 22/01/2025 -> pending confirmation
-    @{ Family = "ThinkPad T14s Gen 2i"; Version = "N35UJ17W (1.54 )"; Path = ".\\ThinkPad T14s Gen 2i 1.54" }, # Updated 18/10/2023, weird issue with trying to upgrade to 1.60 
-    #@{ Family = "ThinkPad T14s Gen 2i"; Version = "N35ET60W (1.60 )"; Path = ".\\ThinkPad T14s Gen 2i" }, # Updated 27/01/2025, BIOS version confirmed
-    @{ Family = "ThinkPad T14s Gen 5"; Version = "N46ET19W (1.09 )"; Path = ".\\ThinkPad T14s Gen 5" }, # Updated 05/12/2024, BIOS version confirmed
-    @{ Family = "ThinkPad P15s Gen 2i"; Version = "N34ET64W (1.64 )"; Path = ".\\ThinkPad P15s Gen 2i" }, # Updated 16/12/2024, BIOS version confirmed
-    @{ Family = "ThinkPad P16s Gen 3"; Version = "R2DET35W (1.20 )"; Path = ".\\ThinkPad P16s Gen 3" }, # Updated 09/12/2024, BIOS version confirmed
-    @{ Family = "ThinkCentre M920s"; Version = "M1UKT77A"; Path = ".\\ThinkCentre M920s" }, # Updated 25/04/2024, BIOS version confirmed
-    @{ Family = "ThinkCentre M920q"; Version = "M1UKT77A"; Path = ".\\ThinkCentre M920q" }, # Updated 25/04/2024, BIOS version confirmed
-    @{ Family = "ThinkCentre M80s Gen 3"; Version = "M40KT57A"; Path = ".\\ThinkCentre M80s Gen 3" }, # Updated 01/11/2024, BIOS version confirmed
-    @{ Family = "ThinkCentre M80q"; Version = "M2WKT61A"; Path = ".\\ThinkCentre M80q" } # Updated 17/12/2024, BIOS version confirmed
+    @{ Family = "ThinkPad T490s"; Version = "N2JETA7W (1.85 )"; Path = ".\ThinkPad T490s" }, # Updated 12/12/2024, BIOS version confirmed
+    @{ Family = "ThinkPad T14s Gen 1"; Version = "N2YET25W (1.14 )"; Path = ".\ThinkPad T14s Gen 1" }, # Updated 22/01/2025 -> pending confirmation
+    @{ Family = "ThinkPad T14s Gen 2i"; Version = "N35UJ17W (1.54 )"; Path = ".\ThinkPad T14s Gen 2i 1.54" }, # Updated 18/10/2023, weird issue with trying to upgrade to 1.60
+    #@{ Family = "ThinkPad T14s Gen 2i"; Version = "N35ET60W (1.60 )"; Path = ".\ThinkPad T14s Gen 2i" }, # Updated 27/01/2025, BIOS version confirmed
+    @{ Family = "ThinkPad T14s Gen 5"; Version = "N46ET19W (1.09 )"; Path = ".\ThinkPad T14s Gen 5" }, # Updated 05/12/2024, BIOS version confirmed
+    @{ Family = "ThinkPad P15s Gen 2i"; Version = "N34ET64W (1.64 )"; Path = ".\ThinkPad P15s Gen 2i" }, # Updated 16/12/2024, BIOS version confirmed
+    @{ Family = "ThinkPad P16s Gen 3"; Version = "R2DET35W (1.20 )"; Path = ".\ThinkPad P16s Gen 3" }, # Updated 09/12/2024, BIOS version confirmed
+    @{ Family = "ThinkCentre M920s"; Version = "M1UKT77A"; Path = ".\ThinkCentre M920s" }, # Updated 25/04/2024, BIOS version confirmed
+    @{ Family = "ThinkCentre M920q"; Version = "M1UKT77A"; Path = ".\ThinkCentre M920q" }, # Updated 25/04/2024, BIOS version confirmed
+    @{ Family = "ThinkCentre M80s Gen 3"; Version = "M40KT57A"; Path = ".\ThinkCentre M80s Gen 3" }, # Updated 01/11/2024, BIOS version confirmed
+    @{ Family = "ThinkCentre M80q"; Version = "M2WKT61A"; Path = ".\ThinkCentre M80q" } # Updated 17/12/2024, BIOS version confirmed
 )
 
 # Main Script Logic


### PR DESCRIPTION
## Summary
- use standard Windows path separators for log and working directories
- employ `Join-Path` for file operations in BIOS update function
- clean up BIOS configuration dictionary paths

## Testing
- `pwsh -Command "Get-Date"` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_689649d1494c83298e7df09208f75d67